### PR TITLE
Switch to `data.table` for memory intensive pivoting

### DIFF
--- a/analysis/data_development_med_status_counts.R
+++ b/analysis/data_development_med_status_counts.R
@@ -1,20 +1,30 @@
 library(magrittr)
+library(data.table)
 
 # Load data
 df_med_status <- readr::read_csv(
   here::here("output", "data_development", "med_status_data_development.csv.gz")
 )
 
+# Convert data frame to data.table
+setDT(df_med_status)
+
 # Extract all variables to be rechaped into long format
 med_status_count_var_names <- names(df_med_status)[2:length(names(df_med_status))]
 
 # Restructure data into 'long' format
-df_med_status_tidy <- df_med_status %>%
-  tidyr::pivot_longer(
-    cols = c(med_status_count_var_names),
-    names_to = c("time", "selected_codes", "med_status"),
-    names_sep = "_"
-  )
+df_med_status_tidy <- melt(
+  df_med_status,
+  id_.vars = "patient_id",
+  measure.vars = med_status_count_var_names,
+  variable.name = "variable",
+  value.name = "value"
+)
+
+df_med_status_tidy[, c("time", "selected_codes", "med_status") := tstrsplit(variable, "_")][, variable := NULL]
+
+# Convert to tibble
+df_med_status_tidy <- tibble::as_tibble(df_med_status_tidy)
 
 # Calculate sum and apply statistical disclosure control
 df_med_status_summary <- df_med_status_tidy %>%


### PR DESCRIPTION
This is just a blind attempt to resolve the error (https://jobs.opensafely.org/opensafely-internal/pharmacy-first-data-development/23595/6k2hozpy4kkubr5c/) and may not be the reason why the job is failing, but hopefully this will get us one step further.