### PR TITLE
Remove bp and contraception service

### DIFF
--- a/analysis/dataset_definition_med_status_data_development.py
+++ b/analysis/dataset_definition_med_status_data_development.py
@@ -37,11 +37,11 @@ pharmacy_first_launch_date = date(2024, 2, 1)
 time_interval = months(6)
 
 pharmacy_first_ids = clinical_events.where(
-    clinical_events.snomedct_code.is_in(pharmacy_first_event_codes)
+    clinical_events.snomedct_code.is_in(pharmacy_first_event_codes[2:4])
 ).consultation_id
 
 pharmacy_first_dates = clinical_events.where(
-    clinical_events.snomedct_code.is_in(pharmacy_first_event_codes)
+    clinical_events.snomedct_code.is_in(pharmacy_first_event_codes[2:4])
 ).date
 
 # Select medications


### PR DESCRIPTION
- analysis/dataset_definition_med_status_data_development.py currently uses all four event codes, so I have limited this to use only the PF 2 codes. 

- analysis/dataset_definition_pf_data_development.py already has commented out the unnecessary pf codes.

- analysis/measures_definition_clinical_codes.py has all four codes, but I've left it as is, because it forms the graphs bit of the report, where its probably useful to see all four services?

- The R files do not need to be changed because the data they are sourcing has been already constrained to the codes we want?
