### PR TITLE
Remove BP and Contraception services

### DIFF
--- a/analysis/data_development_pf_code_count_distinct.R
+++ b/analysis/data_development_pf_code_count_distinct.R
@@ -2,9 +2,12 @@ library(magrittr)
 library(here)
 library(readr)
 library(dplyr)
+library(arrow)
 
 # Load data
-df_tmp <- read_csv(here("output", "data_development", "pf_codes_data_development.csv.gz"))
+df_tmp <- arrow::read_feather(
+  here::here("output", "data_development", "pf_codes_data_development.arrow")
+)
 
 print("Load data successfully")
 

--- a/analysis/data_development_pf_code_count_events.R
+++ b/analysis/data_development_pf_code_count_events.R
@@ -2,9 +2,12 @@ library(magrittr)
 library(here)
 library(readr)
 library(dplyr)
+library(arrow)
 
 # Load data
-df_tmp <- read_csv(here("output", "data_development", "pf_codes_data_development.csv.gz"))
+df_tmp <- arrow::read_feather(
+  here::here("output", "data_development", "pf_codes_data_development.arrow")
+)
 
 print("Load data successfully")
 

--- a/analysis/data_development_pf_code_count_pathways.R
+++ b/analysis/data_development_pf_code_count_pathways.R
@@ -2,9 +2,12 @@ library(magrittr)
 library(here)
 library(readr)
 library(dplyr)
+library(arrow)
 
 # Load data
-df_tmp <- read_csv(here("output", "data_development", "pf_codes_data_development.csv.gz"))
+df_tmp <- arrow::read_feather(
+  here::here("output", "data_development", "pf_codes_data_development.arrow")
+)
 
 print("Load data successfully")
 

--- a/analysis/dataset_definition_med_status_data_development.py
+++ b/analysis/dataset_definition_med_status_data_development.py
@@ -13,9 +13,9 @@ dataset.define_population(patients.exists_for_patient())
 
 # Pharmacy first clinical codes
 pharmacy_first_event_codes = [
-    "1659111000000107",
-    "1659121000000101",
+    # Community Pharmacist (CP) Consultation Service for minor illness (procedure)
     "1577041000000109",
+    # Pharmacy First service (qualifier value)
     "983341000000102",
 ]
 

--- a/analysis/dataset_definition_pf_data_development.py
+++ b/analysis/dataset_definition_pf_data_development.py
@@ -16,12 +16,6 @@ pharmacy_first_events_dict = {
     "comm_pharm_consultation_service": ["1577041000000109"],
     # Pharmacy First service (qualifier value)
     "pharm_first_service": ["983341000000102"],
-    # We are not including Blood Pressure and Contraception services for now
-    # as they are technically not directly part of Pharmacy First
-    # Community Pharmacy (CP) Blood Pressure (BP) Check Service (procedure)
-    # "comm_pharm_bp_service": ["1659111000000107"],
-    # Community Pharmacy (CP) Contraception Service (procedure)
-    # "comm_pharm_contraception_service": ["1659121000000101"],
 }
 
 pharmacy_first_event_codes = [

--- a/analysis/measures_definition_clinical_codes.py
+++ b/analysis/measures_definition_clinical_codes.py
@@ -6,10 +6,6 @@ measures.configure_dummy_data(population_size=10000)
 
 # Dictionary of pharmacy first codes
 pharmacy_first_event_codes = {
-    # Community Pharmacy (CP) Blood Pressure (BP) Check Service (procedure)
-    "blood_pressure_service": ["1659111000000107"],
-    # Community Pharmacy (CP) Contraception Service (procedure)
-    "contraception_service": ["1659121000000101"],
     # Community Pharmacist (CP) Consultation Service for minor illness (procedure)
     "consultation_service": ["1577041000000109"],
     # Pharmacy First service (qualifier value)

--- a/project.yaml
+++ b/project.yaml
@@ -9,10 +9,10 @@ actions:
     run: >
       ehrql:v1 generate-dataset analysis/dataset_definition_pf_data_development.py
         --test-data-file analysis/test_dataset_definition_pf_data_development.py
-        --output output/data_development/pf_codes_data_development.csv.gz
+        --output output/data_development/pf_codes_data_development.arrow
     outputs:
       highly_sensitive:
-        dataset: output/data_development/pf_codes_data_development.csv.gz
+        dataset: output/data_development/pf_codes_data_development.arrow
 
   generate_med_status_data_development:
     run: >

--- a/reports/pharmacy_first_data_development.Rmd
+++ b/reports/pharmacy_first_data_development.Rmd
@@ -72,15 +72,11 @@ med_status_label_desc <- c(
 
 # Pharmacy first codes
 pf_consultation_label <- c(
-  "count_blood_pressure_service",
-  "count_contraception_service",
   "count_consultation_service",
   "count_pharmacy_first_service"
 )
 
 pf_consultation_label_desc <- c(
-  "Blood Pressure Check Service (1659111000000107)",
-  "Contraception Service (1659121000000101)",
   "Consultation Service for minor illness (1577041000000109)",
   "Pharmacy First service (983341000000102)"
 )
@@ -150,7 +146,8 @@ tab_med_status_counts <- df_tab_med_status_counts %>%
     columns = med_status
   ) %>%
   tab_header(
-    title = md("**Count of medication status for any medication from 1st Aug 2023 to 31st Jul 2024**"),
+    title = md("**Descriptive statistics for medication status**"),
+    subtitle = "This includes all medications issued between 1st Aug 2023 and 31st Jul 2024",
   )
 
 gtsave(
@@ -235,7 +232,8 @@ tab_pf_med_status_counts <- df_tab_pf_med_status_counts %>%
     locations = cells_column_labels(columns = c(pre_pfmedid, post_pfmedid))
   ) %>%
   tab_header(
-    title = md("**Count of medication status before and after the Pharmacy First launch date (31st Jan 2024)**"),
+    title = md("**Descriptive statistics for medication status**"),
+    subtitle = "Counts are broken down by type of medication and timeframe",
   )
 
 gtsave(
@@ -255,7 +253,6 @@ To provide further insight, consultation ID counts were segmented by clinical se
 
 ```{r, fig.height=5, fig.width=8, echo = FALSE, warning=FALSE}
 # Read the CSV file
-
 plot_code_counts <- df_codes_count_measures %>%
   group_by(measure, interval_end) %>%
   mutate(
@@ -427,11 +424,11 @@ tab_pf_codes_count_summary <- df_pivot_codes_count_summary %>%
     columns = summary_stat
   ) %>%
   tab_footnote(
-    footnote = "All clinical events.",
+    footnote = "Total number of distinct consultation IDs.",
     locations = cells_column_labels(columns = c(pre_all, post_all))
   ) %>%
   tab_footnote(
-    footnote = "Clinical events taking place on the same day as a Pharmacy First consultation .",
+    footnote = "Clinical events taking place on the same day as a Pharmacy First consultation.",
     locations = cells_column_labels(columns = c(pre_pfdate, post_pfdate))
   ) %>%
   tab_footnote(
@@ -439,7 +436,8 @@ tab_pf_codes_count_summary <- df_pivot_codes_count_summary %>%
     locations = cells_column_labels(columns = c(pre_pfid, post_pfid))
   ) %>%
   tab_header(
-    title = md("**Count of clinical events before and after the Pharmacy First launch date (31st Jan 2024)**"),
+    title = md("**Descriptive statistics for clinical events related to Pharmacy First services**"),
+    subtitle = "Counts are broken down by different summary statistics and timeframe",
   )
 
 gtsave(
@@ -448,7 +446,6 @@ gtsave(
 )
 
 tab_pf_codes_count_summary
-
 ```
 
 * Pharmacy First pathways (sinusitis, sore throat, otitis media, infected insect bites, impetigo, shingles, uncomplicated urinary tract infections)


### PR DESCRIPTION
Closes #43 

Here some additional change not covered in the ticket:
- Because we need to rerun the `generate_pf_codes_data_development` anyway I changed the ouput to `.arrow` format as this makes it easier to work with large files.
- I improved some text in the report as part of 4d15747da0a8ab219f4e788c49efea5227bae368